### PR TITLE
Rebuild for both OpenSSL 1 and 3

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+channels:
+  jcmorin-ana-org: qt
+
+upload_without_merge: true

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-channels:
-  jcmorin-ana-org: qt
-
-upload_without_merge: true

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
       - openssl3.patch
       - find-boost.patch
 build:
-  number: 1
+  number: 2
   # linux-s390x is skipped because cyrus-sasl isn't available on s390x
   skip: True  # [win or (linux and s390x)]
 
@@ -36,7 +36,7 @@ requirements:
     - openssl {{ openssl }}
     - cyrus-sasl 2.1.28  # [not win]
   run:
-    - openssl 3.*
+    - openssl  # exact pin handled through openssl run_exports
 test:
   commands:
     - mysql_config --version


### PR DESCRIPTION
Rebuild for both OpenSSL 1 and 3. This is required for [qt-main](https://github.com/AnacondaRecipes/qt-main-feedstock/pull/5).

Depends on:
* https://github.com/AnacondaRecipes/cyrus-sasl-feedstock/pull/6